### PR TITLE
fix: restore settings page and configure buy1 amount display

### DIFF
--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -17,7 +17,7 @@ const { VueLoaderPlugin } = require('vue-loader')
  * that provide pure *.vue files that need compiling
  * https://simulatedgreg.gitbooks.io/electron-vue/content/en/webpack-configurations.html#white-listing-externals
  */
-let whiteListedModules = ['vue', 'element-ui']
+let whiteListedModules = ['vue', 'element-ui', 'axios']
 
 let rendererConfig = {
   entry: {

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/web/*
 build/*
 !build/icons
 node_modules/
+node_modules
 npm-debug.log
 npm-debug.log.*
 thumbs.db

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",
     "build:web": "cross-env BUILD_TARGET=web node .electron-vue/build.js",
     "dev": "node .electron-vue/dev-runner.js",
+    "test:stock-format": "node test/stock-format.test.js",
+    "test:renderer-config": "node test/renderer-webpack-config.test.js",
     "pack": "npm run pack:main && npm run pack:renderer",
     "pack:main": "cross-env NODE_ENV=production webpack --progress --colors --config .electron-vue/webpack.main.config.js",
     "pack:renderer": "cross-env NODE_ENV=production webpack --progress --colors --config .electron-vue/webpack.renderer.config.js",

--- a/src/main/utils/db.js
+++ b/src/main/utils/db.js
@@ -22,6 +22,7 @@ const defaultConfig = {
   errCodeChecked: false,
   is_mouse: '0',
   is_display_page: true,
+  is_display_buy1_amount: true,
   display_model: '1',
   display_shares_list: [],
   moyu_text: 'Hello',

--- a/src/main/utils/stock.js
+++ b/src/main/utils/stock.js
@@ -417,7 +417,15 @@ const stockUtils = {
         return results;
     },
 
-    getData: function (code, callback) {
+    formatStockQuoteText({ stockName, currPrice, percentage, buy1AmountText, showBuy1Amount }) {
+        var text = stockName + '  ' + currPrice + "/" + percentage + "%";
+        if (showBuy1Amount !== false) {
+            text = text + '  ' + buy1AmountText;
+        }
+        return text + "\n";
+    },
+
+    getData: function (code, callback, options) {
         // var codeArr = code.split(",");
         var that = this;
         // var textAll = "";
@@ -475,10 +483,22 @@ const stockUtils = {
         //     });
         that.requestStock(urlAll, function (res) {
             callback(res)
-        })
+        }, options)
     },
-    requestStock(url, func) {
+    requestStock(url, func, options) {
         // console.log(url);
+        var showBuy1Amount = true;
+        if (options && Object.prototype.hasOwnProperty.call(options, 'showBuy1Amount')) {
+            showBuy1Amount = options.showBuy1Amount !== false;
+        } else {
+            try {
+                const db = require('./db').default;
+                showBuy1Amount = db.get('is_display_buy1_amount') !== false;
+            } catch (err) {
+                console.error('读取买一金额显示配置失败:', err && err.message ? err.message : err);
+            }
+        }
+
         request
             .get(url)
             .buffer(true)
@@ -522,7 +542,13 @@ const stockUtils = {
                         sealAmountInWan = parseFloat(param.value) / 10000;
                     }
 
-                    var text = stockName + '  ' + currPrice + "/" + percentage + "%" + '  '+ param.value + param.unit + "\n";
+                    var text = stockUtils.formatStockQuoteText({
+                        stockName: stockName,
+                        currPrice: currPrice,
+                        percentage: percentage,
+                        buy1AmountText: param.value + param.unit,
+                        showBuy1Amount: showBuy1Amount
+                    });
                     textAll = textAll + text;
                     // console.log(textAll);
                 }

--- a/src/main/utils/stockMonitor.js
+++ b/src/main/utils/stockMonitor.js
@@ -99,7 +99,7 @@ export default {
                 } catch (err) {
                     console.error("解析股票数据回调异常:", err);
                 }
-            });
+            }, { showBuy1Amount: true });
         } catch (error) {
             console.error("检查股票数据时出错:", error);
         }

--- a/src/renderer/components/setting.vue
+++ b/src/renderer/components/setting.vue
@@ -179,6 +179,9 @@
           <el-form-item label="显示分页">
             <el-switch v-model="is_display_page"></el-switch>
           </el-form-item>
+          <el-form-item label="买一金额">
+            <el-switch v-model="is_display_buy1_amount"></el-switch>
+          </el-form-item>
           <el-form-item label="摸鱼文字">
             <el-input style="width:130px;" v-model="moyu_text" maxlength="100" size="mini" placeholder="请输入摸鱼文字"
               prefix-icon="el-icon-umbrella"></el-input>
@@ -268,6 +271,7 @@ export default {
         key_type: 0
       },
       is_display_page: true,
+      is_display_buy1_amount: true,
       is_display_joke: false,
       is_display_shares: false,
       stock_code: [], // 存储 { code: string, name: string }
@@ -540,6 +544,7 @@ export default {
       this.lmchecked = db.get("errCodeChecked");
 
       this.is_display_page = db.get("is_display_page");
+      this.is_display_buy1_amount = db.get("is_display_buy1_amount") !== false;
 
       const savedStocks = db.get("display_shares_list") || [];
       this.stock_code = savedStocks.map(stock => ({
@@ -592,6 +597,7 @@ export default {
         "key_auto": this.keyAuto + "+" + this.keyAutoX,
         "errCodeChecked": this.form.errCodeChecked,
         "is_display_page": this.is_display_page,
+        "is_display_buy1_amount": this.is_display_buy1_amount,
         "display_shares_list": stockList, // 使用清理后的股票数据
         "moyu_text": this.moyu_text,
         "limit_up_alert_enabled": this.limit_up_alert_enabled,

--- a/test/renderer-webpack-config.test.js
+++ b/test/renderer-webpack-config.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+const rendererConfig = require('../.electron-vue/webpack.renderer.config');
+const externals = rendererConfig.externals.flat();
+
+assert(
+  !externals.includes('axios'),
+  'axios must be bundled into the renderer to avoid runtime require failures before pages mount'
+);
+
+console.log('renderer webpack config tests passed');

--- a/test/stock-format.test.js
+++ b/test/stock-format.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+function loadStockUtils() {
+  const filename = path.resolve(__dirname, '../src/main/utils/stock.js');
+  const transformed = fs
+    .readFileSync(filename, 'utf8')
+    .replace(/export default stockUtils;\s*$/, 'module.exports = stockUtils;');
+
+  const mod = new Module(filename, module);
+  mod.filename = filename;
+  mod.paths = Module._nodeModulePaths(path.dirname(filename));
+  const originalRequire = mod.require.bind(mod);
+  mod.require = function requireForTest(request) {
+    if (request === 'superagent') return {};
+    if (request === 'superagent-charset') return function noop() {};
+    return originalRequire(request);
+  };
+  mod._compile(transformed, filename);
+  return mod.exports;
+}
+
+const stockUtils = loadStockUtils();
+
+assert.strictEqual(typeof stockUtils.formatStockQuoteText, 'function');
+
+assert.strictEqual(
+  stockUtils.formatStockQuoteText({
+    stockName: 'ST京机',
+    currPrice: '9.07',
+    percentage: '0.44',
+    buy1AmountText: '15.7818W',
+    showBuy1Amount: true
+  }),
+  'ST京机  9.07/0.44%  15.7818W\n'
+);
+
+assert.strictEqual(
+  stockUtils.formatStockQuoteText({
+    stockName: 'ST京机',
+    currPrice: '9.07',
+    percentage: '0.44',
+    buy1AmountText: '15.7818W',
+    showBuy1Amount: false
+  }),
+  'ST京机  9.07/0.44%\n'
+);
+
+console.log('stock format tests passed');


### PR DESCRIPTION
## Summary
- add a settings toggle for showing/hiding the buy1 amount in stock display text
- keep stock monitor parsing independent by forcing buy1 amount in monitor calls
- bundle axios in renderer builds to prevent settings page runtime blank-screen failures
- add focused tests for stock display formatting and renderer webpack externals

## Verification
- npm run test:stock-format
- npm run test:renderer-config
- npm run pack:renderer
- npm run dev (settings page loaded; no Cannot find module 'axios' runtime error)